### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 An MCP (Model Context Protocol) server that enables AI agents to establish and manage persistent SSH sessions.
 
+<a href="https://glama.ai/mcp/servers/@devnullvoid/mcp-ssh-session">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@devnullvoid/mcp-ssh-session/badge" alt="SSH Session MCP server" />
+</a>
+
 ## Features
 
 - **Persistent Sessions**: SSH connections are reused across multiple command executions


### PR DESCRIPTION
This PR adds a badge for the [MCP SSH Session](https://glama.ai/mcp/servers/@devnullvoid/mcp-ssh-session) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@devnullvoid/mcp-ssh-session">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@devnullvoid/mcp-ssh-session/badge" alt="SSH Session MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.