### PR TITLE
fix: import get_logger from logging_manager to fix 'send_keys, read_s…

### DIFF
--- a/mcp_ssh_session/server.py
+++ b/mcp_ssh_session/server.py
@@ -4,6 +4,7 @@ import os
 from typing import Optional
 from fastmcp import FastMCP
 from .session_manager import SSHSessionManager
+from .logging_manager import get_logger
 
 
 # Initialize the MCP server


### PR DESCRIPTION
is commit fixes the NameError in read_screen and send_keys tools by adding the missing from .logging_manager import get_logger import to server.py, which was broken by the PTY mode merge.